### PR TITLE
Add PGP verification on installation by `curl`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,46 @@
+---
+name: Create release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create_release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get latest release tag
+        id: latest_release
+        run: |
+          latest_tag=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "::set-output name=tag::${latest_tag}"
+      - name: Get current release tag
+        id: current_release
+        run: echo "::set-output name=tag::${GITHUB_REF/refs\/tags\//}"
+      - name: Build changelog
+        id: changelog
+        run: |
+          body=$(git log --pretty=oneline ${{ steps.latest_release.outputs.tag }}..${{ steps.current_release.outputs.tag }})
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::${body}"
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.current_release.outputs.tag }}
+          body: |
+            # Changelog
+
+            ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 .gitleaks.toml
 .vscode/*
 !.vscode/settings.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,42 +1,48 @@
+---
+default_stages: ["commit"]
+exclude: ^.gitleaks.toml$
 repos:
-  - repo: local
-    hooks:
-      - id: pre-commit-autoupdate
-        name: pre-commit-autoupdate
-        entry: pre-commit autoupdate
-        language: system
-        pass_filenames: false
-        verbose: true
   # Security
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.1.0
+    rev: v1.3.0
     hooks:
       - id: detect-secrets
+        stages: ["commit", "push"]
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.2.1
+    rev: v8.11.0
     hooks:
       - id: gitleaks
+        stages: ["commit", "push"]
   # Markdown
-  - repo: https://github.com/jackdewinter/pymarkdown
-    rev: 0.9.2
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.32.1
     hooks:
-      - id: pymarkdown
+      - id: markdownlint
   # Shell
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.1
+    rev: v0.8.0.4
     hooks:
       - id: shellcheck
+        exclude: ^mvnw$
+  # Yaml
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.27.1
+    hooks:
+      - id: yamllint
   # Other
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
-      - id: check-yaml
       - id: check-json
-      - id: detect-aws-credentials
       - id: detect-private-key
+        stages: ["commit", "push"]
       - id: end-of-file-fixer
+        stages: ["commit"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
       - id: no-commit-to-branch
       - id: trailing-whitespace
+        stages: ["commit"]
+ci:
+  autofix_prs: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: format-kotlin
   name: Ktlint Check
-  description: Runs KTLint over Kotlin source files
+  description: Runs ktlint over Kotlin source files
   entry: hooks/ktlint.sh
   language: script
   types: [kotlin]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 150
+    level: warning

--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
-# pre-commit-ktlint
+# Klint pre-commit hooks
 
-This project provides utilities for ensuring that your Kotlin code is nicely formatted by using [pre-commit](https://pre-commit.com/) hooks
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/shoru-sssssaaaaaa/pre-commit-ktlint/main.svg)](https://results.pre-commit.ci/latest/github/shoru-sssssaaaaaa/pre-commit-ktlint/main)
 
-### Example usage
+1. [format-kotlin](#format-kotlin)
+
+## Description
+
+Take into account that in case `ktlint` is not installed locally it will be
+automatically installed **globally**. For that it requires some additional
+dependencies to be installed in advance (please use one of the options below).
+
+- [brew](https://brew.sh/)
+- [curl](https://curl.se/) and [gnupg](https://www.gnupg.org/)
+
+## Documentation
+
+<!-- markdownlint-disable-next-line MD013 -->
+> `<rev>` in the examples below, is the latest revision tag from [shoru-sssssaaaaaa/pre-commit-ktlint](https://github.com/shoru-sssssaaaaaa/pre-commit-ktlint/releases)
+> repository.
+
+### format-kotlin
 
 ```yaml
-- repo: https://github.com/shoru-sssssaaaaaa/pre-commit-ktlint
-    rev: v0.0.5
+repos:
+  - repo: https://github.com/shoru-sssssaaaaaa/pre-commit-ktlint
+    rev: <rev>
     hooks:
       - id: format-kotlin
-        args: ["src/**/*.kt", "!src/**/*Test.kt"]
-        stages: ["commit"]
+        args: ["src/**/*.kt"]
 ```
 
-### Related Guide
-
-KTlint: https://ktlint.github.io/
+> `args` is optional. In this example you can run `ktlint` on specific path.

--- a/hooks/_installation.sh
+++ b/hooks/_installation.sh
@@ -2,9 +2,9 @@
 set -eu
 if ! command -v ktlint &> /dev/null
 then
+  echo "Installing ktlint..."
   if ! command -v brew &> /dev/null
   then
-    echo "Installing ktlint..."
     curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.46.1/ktlint && chmod a+x ktlint
     echo "Installation done"
     echo "Verifying ktlint..."
@@ -16,11 +16,14 @@ then
       mv ktlint /usr/local/bin/ktlint
     else
       echo -e "Verification failed"
+      echo "Uninstalling ktlint..."
       rm -f ktlint.asc
       rm -f ktlint
+      echo "klint uninstalled"
       exit 1
     fi
   else
     brew install ktlint
+    echo "Installation done"
   fi
 fi

--- a/hooks/_installation.sh
+++ b/hooks/_installation.sh
@@ -4,8 +4,6 @@ if ! command -v ktlint &> /dev/null
 then
   if ! command -v brew &> /dev/null
   then
-    brew install ktlint
-  else
     echo "Installing ktlint..."
     curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.46.1/ktlint && chmod a+x ktlint
     echo "Installation done"
@@ -22,5 +20,7 @@ then
       rm -f ktlint
       exit 1
     fi
+  else
+    brew install ktlint
   fi
 fi

--- a/hooks/_installation.sh
+++ b/hooks/_installation.sh
@@ -2,6 +2,25 @@
 set -eu
 if ! command -v ktlint &> /dev/null
 then
-    echo "Installing KTlint..."
-    curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.45.1/ktlint && chmod a+x ktlint
+  if ! command -v brew &> /dev/null
+  then
+    brew install ktlint
+  else
+    echo "Installing ktlint..."
+    curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.46.1/ktlint && chmod a+x ktlint
+    echo "Installation done"
+    echo "Verifying ktlint..."
+    curl -sS https://keybase.io/ktlint/pgp_keys.asc | gpg --import
+    curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.46.1/ktlint.asc
+    if gpg --verify ktlint.asc ktlint ; then
+      echo "Verification passed"
+      rm -f ktlint.asc
+      mv ktlint /usr/local/bin/ktlint
+    else
+      echo -e "Verification failed"
+      rm -f ktlint.asc
+      rm -f ktlint
+      exit 1
+    fi
+  fi
 fi

--- a/hooks/ktlint.sh
+++ b/hooks/ktlint.sh
@@ -3,18 +3,18 @@ set -eu
 SCRIPT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 bash "${SCRIPT_DIR}"/_installation.sh
 
-args=()
 i=1
 for arg in "$@"; do
-  snyk_args+=("$arg")
+  ktlint_args+=("$arg")
   i=$((i + 1))
 done
 
 if [[ $i -gt 1 ]]; then
-    echo "Kotlin Format check with KTlint is running against specified files..."
-    echo "${snyk_args[*]}"
-    ktlint "${snyk_args[*]}"
+    echo "Kotlin Format check with ktlint is running against specified files..."
+    echo "${ktlint_args[*]}"
+    ktlint "${ktlint_args[*]}"
 else
-    echo "Kotlin format check with KTlint is running..."
+    echo "Kotlin format check with ktlint is running..."
     ktlint
 fi
+echo "Kotlin format check finished"


### PR DESCRIPTION
# Changelog

## Add "Create release" pipeline

This pipeline helps to create a release triggered on a tag creation. To create a release:

```bash
git checkout main # based on latest main
git pull # be sure that it is up-to-date
git tag v1.2.3 # random version for an example
git push origin v1.2.3 # it triggers the pipeline and new release will be created
```

## Add `gpg` support

[Official documentation](https://ktlint.github.io/) recommends to verify PGP signature before using `ktlint`. This verification has been added on an installation step using `curl`.

## Add `brew` support

This script gives precedence to `brew` in case this script is running on a machine where `brew` tool is installed, otherwise it downloads `ktlint` with `curl` as it was before. In a future would be good to add additional tools support such as `apt`, `snap`, etc. to avoid manual PGP signature verification.

## Add `pre-commit.ci` support

Very nice feature provided by `pre-commit` developers - separate CI system to run `pre-commit` checks: https://pre-commit.ci/

Highly recommend it as it reduces manual work on running these checks manually using GHA. To configure it:
- Go to https://pre-commit.ci/
- Click on "Sign In With GitHub" and sign in with `shoru-sssssaaaaaa` account.
- Click on `shoru-sssssaaaaaa` on a next screen.
- Click on "manage repos on GitHub" on a next screen.
- In "Repository Access" section you can choose one of the following options:
  - "All repositories"
  - "Only select repositories" and choose `pre-commit-ktlint` from the list

Once you done this you will see in pre-commit.ci dashboard all your runnings. Also, this verification will be run on each PR. Once you merge this PR to `main` then you will see pre-commit.ci badge as green in README file.

## Other

- Add `.idea` to .`gitignore`.
- Improve `pre-commit` config:
  - Bump versions to the latest ones.
  - Remove `pre-commit-autoupdate` as `pre-commit.ci` will create PRs automatically on each new version. So, we do not need to do that manually.
  - Split hooks on `commit` and `push` triggers to make development faster.
  - Change `markdownlint` hook to more stable one.
  - Add `yamllint` hook.
- Rename `ktlint` everywhere to make it lowercase (as tool name is).
- Improve documentation by adding additional information.
- Fix bash script by renaming some variables and removing unused variables.